### PR TITLE
Revert "Update Helm release descheduler to v0.28.0"

### DIFF
--- a/manifest/descheduler.yaml
+++ b/manifest/descheduler.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     chart: descheduler
     repoURL: https://kubernetes-sigs.github.io/descheduler
-    targetRevision: 0.28.0
+    targetRevision: 0.27.1
     helm:
       values: |
         schedule: '*/15 * * * *'


### PR DESCRIPTION
This reverts commit 6aa0b15a34fee166836911eaf4c9da1156df588b.